### PR TITLE
fix: remove asm feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,9 +24,11 @@
 //! xsave.load();
 //! ```
 
-#![cfg_attr(feature = "asm", feature(asm))]
 #![deny(clippy::all)]
 #![no_std]
+
+#[cfg(feature = "asm")]
+use core::arch::asm;
 
 use bitflags::bitflags;
 use const_default::ConstDefault;


### PR DESCRIPTION
`asm` is now stable.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
