### PR TITLE
fix(doc): let `cargo doc` work on stable rust

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,6 +263,7 @@ impl XSave {
     #[inline]
     #[cfg(feature = "asm")]
     pub extern "C" fn save(&mut self) {
+        #[cfg(all(feature = "asm", not(doc)))]
         unsafe {
             asm!(
                 "xsave   [{}]",
@@ -277,6 +278,7 @@ impl XSave {
     #[inline]
     #[cfg(feature = "asm")]
     pub extern "C" fn load(&self) {
+        #[cfg(all(feature = "asm", not(doc)))]
         unsafe {
             asm!(
                 "xrstor  [{}]",


### PR DESCRIPTION
Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
